### PR TITLE
Add clean_old_data.py to remove stale records based on retention

### DIFF
--- a/scripts/cleanup_old_data.py
+++ b/scripts/cleanup_old_data.py
@@ -1,0 +1,527 @@
+"""
+scripts/cleanup_old_data.py — PDSNO stale record cleanup
+ 
+Remove records older than a configurable retention window from NIB tables that
+accumulate unbounded data in long-running deployments.
+ 
+IMPORTANT — what this script will NOT touch:
+  * events            — immutable by design; DB triggers actively block
+                        DELETE/UPDATE.  The audit trail is permanent.
+  * devices           — live network state; excluded unless explicitly requested.
+  * controllers       — identity records; excluded unless explicitly requested.
+ 
+Safe to clean by default (terminal-state or time-bounded records only):
+  * configs / config_records  — rows in DENIED, ROLLED_BACK, or FAILED status
+  * config_approvals          — approvals linked to those terminal configs
+  * execution_tokens          — single-use tokens already consumed (used = 1)
+  * discovery_reports         — completed scan snapshots
+  * backups                   — point-in-time config snapshots
+  * locks                     — lock rows whose expiry has already passed
+  * policies                  — inactive policies (is_active = 0) past valid_until
+ 
+Usage examples:
+    # Preview what would be removed (dry-run, default behaviour):
+    python scripts/cleanup_old_data.py --db config/pdsno.db --days 90
+ 
+    # Apply the cleanup:
+    python scripts/cleanup_old_data.py --db config/pdsno.db --days 90 --execute
+ 
+    # Clean only discovery reports and used tokens, last 30 days:
+    python scripts/cleanup_old_data.py --db config/pdsno.db --days 30 --execute \\
+        --tables discovery_reports execution_tokens
+ 
+    # Verbose output for debugging:
+    python scripts/cleanup_old_data.py --db config/pdsno.db --days 90 --verbose
+ 
+Exit codes:
+    0  — success (dry-run or execution completed without errors)
+    1  — runtime error during cleanup
+    2  — bad arguments or database not found
+"""
+ 
+from __future__ import annotations
+ 
+import argparse
+import logging
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+ 
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+ 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-8s  %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger(__name__)
+ 
+ 
+# ---------------------------------------------------------------------------
+# Table registry
+# ---------------------------------------------------------------------------
+ 
+@dataclass(frozen=True)
+class TableSpec:
+    """
+    Describes how to identify and delete stale rows in one NIB table.
+ 
+    Attributes:
+        name:          SQLite table name.
+        ts_column:     Timestamp column for the age comparison (ISO-8601 text).
+        status_filter: Optional additional SQL fragment (no leading AND) that
+                       restricts cleanup to terminal-state rows only.
+        fk_order:      Deletion priority — lower values are deleted first so
+                       FK children are always removed before their parents.
+        description:   Human-readable note printed in dry-run output.
+    """
+    name: str
+    ts_column: str
+    status_filter: Optional[str]
+    fk_order: int
+    description: str
+ 
+ 
+# Ordered so FK children are cleaned before parents.
+# 'events' is deliberately absent — DB triggers make it immutable.
+ALL_TABLE_SPECS: list[TableSpec] = [
+    # ── FK children (order 10) ────────────────────────────────────────────
+    TableSpec(
+        name="config_approvals",
+        ts_column="approved_at",
+        status_filter=None,
+        fk_order=10,
+        description="Approval records linked to terminal config proposals",
+    ),
+    TableSpec(
+        name="execution_tokens",
+        ts_column="issued_at",
+        status_filter="used = 1",
+        fk_order=10,
+        description="Single-use execution tokens that have been consumed",
+    ),
+    # ── Core config tables (order 20) ─────────────────────────────────────
+    TableSpec(
+        name="configs",
+        ts_column="proposed_at",
+        status_filter="status IN ('DENIED', 'ROLLED_BACK', 'FAILED')",
+        fk_order=20,
+        description="Config proposals in a terminal failure/rejection state (NIBStore schema)",
+    ),
+    TableSpec(
+        name="config_records",
+        ts_column="created_at",
+        status_filter="status IN ('DENIED', 'ROLLED_BACK', 'FAILED')",
+        fk_order=20,
+        description="Config records in a terminal failure/rejection state (init_db schema)",
+    ),
+    TableSpec(
+        name="backups",
+        ts_column="created_at",
+        status_filter=None,
+        fk_order=20,
+        description="Point-in-time configuration snapshots",
+    ),
+    # ── Standalone accumulating tables (order 30) ─────────────────────────
+    TableSpec(
+        name="discovery_reports",
+        ts_column="scan_end",
+        status_filter=None,
+        fk_order=30,
+        description="Completed device discovery scan reports",
+    ),
+    TableSpec(
+        name="locks",
+        ts_column="expires_at",
+        status_filter=None,
+        fk_order=30,
+        description="Lock rows whose expiry timestamp has already passed",
+    ),
+    TableSpec(
+        name="policies",
+        ts_column="valid_until",
+        status_filter="is_active = 0",
+        fk_order=30,
+        description="Inactive policies past their valid_until date",
+    ),
+]
+ 
+_SPEC_BY_NAME: dict[str, TableSpec] = {s.name: s for s in ALL_TABLE_SPECS}
+ 
+# The events table is protected at the database level by INSERT triggers.
+# This set is used to produce a clear error message if a caller tries anyway.
+IMMUTABLE_TABLES: frozenset[str] = frozenset({"events"})
+ 
+# These tables hold live network state and are excluded from default runs.
+SENSITIVE_TABLES: frozenset[str] = frozenset({"devices", "controllers"})
+ 
+ 
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+ 
+@dataclass
+class CleanupConfig:
+    db_path: Path
+    retention_days: int
+    dry_run: bool = True
+    tables: list[str] = field(default_factory=list)  # empty → all eligible
+    batch_size: int = 500
+ 
+ 
+@dataclass
+class TableResult:
+    table: str
+    description: str
+    stale_count: int
+    deleted_count: int = 0
+    skipped: bool = False
+    skip_reason: str = ""
+    error: Optional[str] = None
+ 
+ 
+@dataclass
+class CleanupReport:
+    dry_run: bool
+    cutoff: datetime
+    results: list[TableResult] = field(default_factory=list)
+ 
+    @property
+    def total_stale(self) -> int:
+        return sum(r.stale_count for r in self.results if not r.skipped)
+ 
+    @property
+    def total_deleted(self) -> int:
+        return sum(r.deleted_count for r in self.results)
+ 
+    @property
+    def had_errors(self) -> bool:
+        return any(r.error for r in self.results)
+ 
+    def print_summary(self) -> None:
+        mode = "DRY-RUN  (no data was modified)" if self.dry_run else "EXECUTE"
+        log.info("=" * 72)
+        log.info("PDSNO Cleanup Summary  [%s]", mode)
+        log.info("Cutoff : rows older than %s UTC", self.cutoff.strftime("%Y-%m-%d %H:%M:%S"))
+        log.info("=" * 72)
+ 
+        for r in self.results:
+            if r.skipped:
+                log.info("  %-28s  SKIPPED  — %s", r.table, r.skip_reason)
+            elif r.error:
+                log.error("  %-28s  ERROR    — %s", r.table, r.error)
+            elif self.dry_run:
+                log.info(
+                    "  %-28s  %5d stale rows would be removed",
+                    r.table, r.stale_count,
+                )
+            else:
+                log.info(
+                    "  %-28s  %5d / %5d rows removed",
+                    r.table, r.deleted_count, r.stale_count,
+                )
+ 
+        log.info("-" * 72)
+        if self.dry_run:
+            log.info("Total stale rows (would be removed) : %d", self.total_stale)
+            log.info("Re-run with --execute to apply changes.")
+        else:
+            log.info("Total rows removed                  : %d", self.total_deleted)
+ 
+        if self.had_errors:
+            log.warning("One or more tables had errors — review the output above.")
+        log.info("=" * 72)
+ 
+ 
+
+ 
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchone()
+    return bool(row)
+ 
+ 
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()  # noqa: S608
+    return any(row[1] == column for row in rows)
+ 
+ 
+def _build_where(spec: TableSpec, cutoff: datetime) -> tuple[str, list]:
+    """
+    Return (WHERE-clause-string, params-list) for stale-row queries.
+ 
+    The cutoff uses strict less-than so records created exactly at the cutoff
+    boundary are preserved.  The optional status_filter is ANDed in to ensure
+    only terminal-state rows are selected, never live or pending records.
+    """
+    clauses = [f"{spec.ts_column} < ?"]
+    params: list = [cutoff.isoformat()]
+    if spec.status_filter:
+        clauses.append(spec.status_filter)
+    return " AND ".join(clauses), params
+ 
+ 
+def _count_stale(conn: sqlite3.Connection, spec: TableSpec, cutoff: datetime) -> int:
+    where, params = _build_where(spec, cutoff)
+    row = conn.execute(
+        f"SELECT COUNT(*) FROM {spec.name} WHERE {where}", params  # noqa: S608
+    ).fetchone()
+    return row[0] if row else 0
+ 
+ 
+def _delete_stale_batched(
+    conn: sqlite3.Connection,
+    spec: TableSpec,
+    cutoff: datetime,
+    batch_size: int,
+) -> int:
+    """
+    Delete stale rows in fixed-size batches to bound transaction size.
+ 
+    Re-uses exactly the same WHERE logic as _count_stale to guarantee the
+    dry-run count and the executed delete operate on identical row sets.
+    Loops until the number of rows deleted in a batch falls below batch_size,
+    which signals no more matching rows remain.
+    """
+    where, params = _build_where(spec, cutoff)
+    total = 0
+ 
+    while True:
+        cursor = conn.execute(
+            f"""
+            DELETE FROM {spec.name}
+            WHERE rowid IN (
+                SELECT rowid FROM {spec.name}
+                WHERE {where}
+                LIMIT ?
+            )
+            """,  # noqa: S608
+            params + [batch_size],
+        )
+        conn.commit()
+        deleted_this_batch = cursor.rowcount
+        total += deleted_this_batch
+ 
+        if deleted_this_batch < batch_size:
+            break   # fewer than a full batch → nothing left
+ 
+    return total
+ 
+ 
+
+# Per-table orchestration
+
+ 
+def _process_table(
+    conn: sqlite3.Connection,
+    spec: TableSpec,
+    config: CleanupConfig,
+    cutoff: datetime,
+) -> TableResult:
+    result = TableResult(table=spec.name, description=spec.description, stale_count=0)
+ 
+    # Hard guard: immutable tables refuse deletion at the DB level anyway,
+    # but we skip early with a clear message to avoid confusing sqlite3 errors.
+    if spec.name in IMMUTABLE_TABLES:
+        result.skipped = True
+        result.skip_reason = "immutable audit log — DB triggers block DELETE"
+        return result
+ 
+    if not _table_exists(conn, spec.name):
+        result.skipped = True
+        result.skip_reason = "table not present in this database"
+        return result
+ 
+    if not _column_exists(conn, spec.name, spec.ts_column):
+        result.skipped = True
+        result.skip_reason = f"timestamp column '{spec.ts_column}' not found"
+        return result
+ 
+    try:
+        result.stale_count = _count_stale(conn, spec, cutoff)
+ 
+        if config.dry_run or result.stale_count == 0:
+            return result   # nothing to delete, or dry-run stops here
+ 
+        result.deleted_count = _delete_stale_batched(conn, spec, cutoff, config.batch_size)
+ 
+    except sqlite3.Error as exc:
+        log.exception("Database error while processing %r", spec.name)
+        result.error = str(exc)
+ 
+    return result
+ 
+ 
+
+# Public entry point
+
+ 
+def run_cleanup(config: CleanupConfig) -> CleanupReport:
+    """
+    Run (or simulate) NIB cleanup according to *config*.
+ 
+    Raises:
+        FileNotFoundError  — database path does not exist.
+        ValueError         — unknown table name passed in config.tables.
+    Returns:
+        CleanupReport — inspect .had_errors to decide exit code.
+    """
+    if not config.db_path.exists():
+        raise FileNotFoundError(f"Database not found: {config.db_path}")
+ 
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(days=config.retention_days)
+    report = CleanupReport(dry_run=config.dry_run, cutoff=cutoff)
+ 
+    log.info("Database    : %s", config.db_path)
+    log.info(
+        "Retention   : %d day(s)  →  cutoff %s UTC",
+        config.retention_days,
+        cutoff.strftime("%Y-%m-%d %H:%M:%S"),
+    )
+    log.info("Mode        : %s", "DRY-RUN" if config.dry_run else "EXECUTE")
+ 
+    # Resolve which specs to run
+    if config.tables:
+        unknown = set(config.tables) - _SPEC_BY_NAME.keys() - IMMUTABLE_TABLES - SENSITIVE_TABLES
+        if unknown:
+            raise ValueError(
+                f"Unrecognised table name(s): {sorted(unknown)}. "
+                f"Valid targets: {sorted(_SPEC_BY_NAME)}"
+            )
+        for t in config.tables:
+            if t in SENSITIVE_TABLES:
+                log.warning(
+                    "Table %r contains live network state. "
+                    "Verify your intent before using --execute.", t
+                )
+        specs = [_SPEC_BY_NAME[t] for t in config.tables if t in _SPEC_BY_NAME]
+    else:
+        specs = list(ALL_TABLE_SPECS)
+ 
+    # Always process children before parents.
+    specs.sort(key=lambda s: s.fk_order)
+ 
+    conn = sqlite3.connect(str(config.db_path))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA journal_mode = WAL")
+ 
+    try:
+        for spec in specs:
+            log.debug("Processing: %s", spec.name)
+            result = _process_table(conn, spec, config, cutoff)
+            report.results.append(result)
+    finally:
+        conn.close()
+ 
+    report.print_summary()
+    return report
+ 
+ 
+
+# CLI
+
+ 
+def _build_parser() -> argparse.ArgumentParser:
+    default_targets = sorted(s.name for s in ALL_TABLE_SPECS)
+ 
+    p = argparse.ArgumentParser(
+        prog="cleanup_old_data",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--db",
+        required=True,
+        metavar="PATH",
+        type=Path,
+        help="Path to the PDSNO SQLite database (e.g. config/pdsno.db).",
+    )
+    p.add_argument(
+        "--days",
+        required=True,
+        type=int,
+        metavar="N",
+        help="Retention window in days.  Records older than N days are eligible for removal.",
+    )
+    p.add_argument(
+        "--execute",
+        action="store_true",
+        default=False,
+        help=(
+            "Perform the actual deletion.  "
+            "Without this flag the script is a no-op (dry-run)."
+        ),
+    )
+    p.add_argument(
+        "--tables",
+        nargs="+",
+        metavar="TABLE",
+        default=[],
+        help=(
+            "Specific table(s) to clean.  "
+            f"Defaults to all eligible tables: {', '.join(default_targets)}.  "
+            "NOTE: 'events' is always excluded (immutable audit log)."
+        ),
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,
+        metavar="N",
+        help="Rows deleted per transaction (default: 500).  Tune for write pressure.",
+    )
+    p.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        default=False,
+        help="Enable DEBUG logging.",
+    )
+    return p
+ 
+ 
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+ 
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+ 
+    if args.days < 1:
+        parser.error("--days must be a positive integer.")
+    if args.batch_size < 1:
+        parser.error("--batch-size must be a positive integer.")
+ 
+    config = CleanupConfig(
+        db_path=args.db,
+        retention_days=args.days,
+        dry_run=not args.execute,
+        tables=args.tables,
+        batch_size=args.batch_size,
+    )
+ 
+    try:
+        report = run_cleanup(config)
+    except FileNotFoundError as exc:
+        log.error("%s", exc)
+        log.error(
+            "Run 'python scripts/init_db.py --db %s' to initialise it first.", args.db
+        )
+        return 2
+    except ValueError as exc:
+        log.error("%s", exc)
+        return 2
+    except Exception:
+        log.exception("Unexpected error during cleanup")
+        return 1
+ 
+    return 1 if report.had_errors else 0
+ 
+ 
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cleanup_old_data.py
+++ b/scripts/cleanup_old_data.py
@@ -1,3 +1,11 @@
+#!/usr/bin/env python3
+ 
+# Copyright (C) 2025 TENKEI
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file is part of PDSNO.
+# See the LICENSE file in the project root for license information.
+
 """
 scripts/cleanup_old_data.py — PDSNO stale record cleanup
  

--- a/tests/test_cleanup_old_file.py
+++ b/tests/test_cleanup_old_file.py
@@ -1,0 +1,657 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2025 TENKEI
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file is part of PDSNO.
+# See the LICENSE file in the project root for license information.
+
+from __future__ import annotations
+ 
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+ 
+import pytest
+ 
+# Make the scripts/ directory importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+ 
+from cleanup_old_data import ( 
+    CleanupConfig,
+    CleanupReport,
+    TableResult,
+    TableSpec,
+    _build_where,
+    _column_exists,
+    _count_stale,
+    _delete_stale_batched,
+    _process_table,
+    _table_exists,
+    main,
+    run_cleanup,
+)
+ 
+ 
+# ---------------------------------------------------------------------------
+# Schema helpers — mirror the real NIB schema exactly
+# ---------------------------------------------------------------------------
+ 
+_NIB_SCHEMA = """
+PRAGMA foreign_keys = ON;
+ 
+CREATE TABLE IF NOT EXISTS configs (
+    config_id       TEXT PRIMARY KEY,
+    device_id       TEXT NOT NULL,
+    config_hash     TEXT NOT NULL DEFAULT '',
+    category        TEXT NOT NULL DEFAULT 'LOW',
+    status          TEXT NOT NULL DEFAULT 'PENDING',
+    proposed_by     TEXT,
+    approved_by     TEXT,
+    execution_token TEXT,
+    proposed_at     TEXT,
+    approved_at     TEXT,
+    executed_at     TEXT,
+    expiry          TEXT,
+    policy_version  TEXT,
+    rollback_payload TEXT,
+    config_data     TEXT,
+    reason          TEXT,
+    version         INTEGER NOT NULL DEFAULT 0
+);
+ 
+CREATE TABLE IF NOT EXISTS config_records (
+    config_id   TEXT PRIMARY KEY,
+    device_id   TEXT NOT NULL,
+    config_lines TEXT NOT NULL,
+    created_by  TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    approved_by TEXT,
+    approved_at TEXT,
+    executed_at TEXT,
+    status      TEXT NOT NULL,
+    sensitivity TEXT NOT NULL,
+    version     INTEGER DEFAULT 0
+);
+ 
+CREATE TABLE IF NOT EXISTS config_approvals (
+    approval_id  TEXT PRIMARY KEY,
+    config_id    TEXT NOT NULL,
+    approver_id  TEXT NOT NULL,
+    approved_at  TEXT NOT NULL,
+    decision     TEXT NOT NULL,
+    comments     TEXT
+);
+ 
+CREATE TABLE IF NOT EXISTS execution_tokens (
+    token_id   TEXT PRIMARY KEY,
+    config_id  TEXT NOT NULL,
+    device_id  TEXT NOT NULL,
+    issued_by  TEXT NOT NULL,
+    issued_at  TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    signature  TEXT NOT NULL,
+    used       INTEGER DEFAULT 0
+);
+ 
+CREATE TABLE IF NOT EXISTS backups (
+    backup_id       TEXT PRIMARY KEY,
+    device_id       TEXT NOT NULL,
+    config_id       TEXT,
+    config_snapshot TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    created_by      TEXT NOT NULL,
+    metadata        TEXT
+);
+ 
+CREATE TABLE IF NOT EXISTS events (
+    event_id    TEXT PRIMARY KEY,
+    event_type  TEXT NOT NULL,
+    actor       TEXT NOT NULL,
+    subject     TEXT,
+    action      TEXT NOT NULL,
+    decision    TEXT,
+    timestamp   TEXT NOT NULL,
+    payload_ref TEXT,
+    notes       TEXT,
+    signature   TEXT NOT NULL,
+    details     TEXT NOT NULL DEFAULT '{}'
+);
+ 
+CREATE TRIGGER IF NOT EXISTS prevent_event_update
+BEFORE UPDATE ON events
+BEGIN
+    SELECT RAISE(FAIL, 'Event log is immutable — updates not allowed');
+END;
+ 
+CREATE TRIGGER IF NOT EXISTS prevent_event_delete
+BEFORE DELETE ON events
+BEGIN
+    SELECT RAISE(FAIL, 'Event log is immutable — deletions not allowed');
+END;
+ 
+CREATE TABLE IF NOT EXISTS discovery_reports (
+    report_id           TEXT PRIMARY KEY,
+    local_controller_id TEXT NOT NULL,
+    subnet              TEXT NOT NULL,
+    scan_start          TEXT NOT NULL,
+    scan_end            TEXT NOT NULL,
+    devices_found       INTEGER,
+    new_devices         INTEGER,
+    metadata            TEXT
+);
+ 
+CREATE TABLE IF NOT EXISTS locks (
+    lock_id            TEXT PRIMARY KEY,
+    lock_type          TEXT NOT NULL,
+    subject_id         TEXT NOT NULL,
+    held_by            TEXT NOT NULL,
+    acquired_at        TEXT NOT NULL,
+    expires_at         TEXT NOT NULL,
+    associated_request TEXT,
+    status             TEXT NOT NULL DEFAULT 'ACTIVE'
+);
+ 
+CREATE TABLE IF NOT EXISTS policies (
+    policy_id       TEXT PRIMARY KEY,
+    policy_version  TEXT NOT NULL,
+    scope           TEXT NOT NULL,
+    target_region   TEXT,
+    content         TEXT NOT NULL,
+    distributed_by  TEXT NOT NULL,
+    distributed_at  TEXT,
+    valid_from      TEXT,
+    valid_until     TEXT,
+    is_active       INTEGER NOT NULL DEFAULT 1,
+    version         INTEGER NOT NULL DEFAULT 0
+);
+ 
+CREATE TABLE IF NOT EXISTS devices (
+    device_id   TEXT PRIMARY KEY,
+    ip_address  TEXT NOT NULL,
+    mac_address TEXT UNIQUE NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'active',
+    first_seen  TEXT,
+    last_seen   TEXT
+);
+ 
+CREATE TABLE IF NOT EXISTS controllers (
+    controller_id TEXT PRIMARY KEY,
+    role          TEXT NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'validating',
+    validated_at  TEXT
+);
+"""
+ 
+ 
+def _make_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    conn.executescript(_NIB_SCHEMA)
+    conn.commit()
+    return conn
+ 
+ 
+def _ts(age_days: int) -> str:
+    """Return an ISO-8601 UTC timestamp for *now - age_days*."""
+    return (datetime.now(tz=timezone.utc) - timedelta(days=age_days)).isoformat()
+ 
+ 
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+ 
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "pdsno_test.db"
+    conn = _make_db(path)
+ 
+    # configs: 2 stale DENIED (40 days), 1 stale EXECUTED (50 days — must NOT be deleted),
+    #          2 recent PENDING (3 days)
+    conn.executemany(
+        "INSERT INTO configs (config_id, device_id, status, proposed_at) VALUES (?, ?, ?, ?)",
+        [
+            ("cfg-denied-old-1", "dev-1", "DENIED", _ts(40)),
+            ("cfg-denied-old-2", "dev-2", "DENIED", _ts(45)),
+            ("cfg-executed-old", "dev-3", "EXECUTED", _ts(50)),  # terminal but not in filter
+            ("cfg-pending-new-1", "dev-1", "PENDING", _ts(3)),
+            ("cfg-pending-new-2", "dev-2", "PENDING", _ts(1)),
+        ],
+    )
+ 
+    # config_records: 1 stale FAILED (60 days), 1 recent APPROVED (5 days)
+    conn.executemany(
+        """INSERT INTO config_records
+           (config_id, device_id, config_lines, created_by, created_at, status, sensitivity)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        [
+            ("cr-failed-old", "dev-1", "[]", "gc-1", _ts(60), "FAILED", "LOW"),
+            ("cr-approved-new", "dev-2", "[]", "gc-1", _ts(5), "APPROVED", "LOW"),
+        ],
+    )
+ 
+    # execution_tokens: 2 used (old), 1 unused (old — must NOT be deleted), 1 used (recent)
+    conn.executemany(
+        """INSERT INTO execution_tokens
+           (token_id, config_id, device_id, issued_by, issued_at, expires_at, signature, used)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        [
+            ("tok-used-old-1", "cfg-denied-old-1", "dev-1", "gc-1", _ts(40), _ts(39), "sig", 1),
+            ("tok-used-old-2", "cfg-denied-old-2", "dev-2", "gc-1", _ts(45), _ts(44), "sig", 1),
+            ("tok-unused-old", "cfg-pending-new-1", "dev-1", "gc-1", _ts(35), _ts(34), "sig", 0),
+            ("tok-used-new", "cfg-pending-new-2", "dev-2", "gc-1", _ts(2), _ts(1), "sig", 1),
+        ],
+    )
+ 
+    # discovery_reports: 3 old, 1 recent
+    conn.executemany(
+        """INSERT INTO discovery_reports
+           (report_id, local_controller_id, subnet, scan_start, scan_end)
+           VALUES (?, ?, ?, ?, ?)""",
+        [
+            ("rpt-1", "lc-1", "10.0.0.0/24", _ts(35), _ts(35)),
+            ("rpt-2", "lc-1", "10.0.1.0/24", _ts(40), _ts(40)),
+            ("rpt-3", "lc-2", "10.0.2.0/24", _ts(50), _ts(50)),
+            ("rpt-new", "lc-1", "10.0.0.0/24", _ts(2), _ts(2)),
+        ],
+    )
+ 
+    # locks: 2 expired (old), 1 active (future expiry)
+    conn.executemany(
+        """INSERT INTO locks
+           (lock_id, lock_type, subject_id, held_by, acquired_at, expires_at, status)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        [
+            ("lk-exp-1", "DEVICE", "dev-1", "lc-1", _ts(40), _ts(39), "ACTIVE"),
+            ("lk-exp-2", "CONFIG", "cfg-1", "lc-2", _ts(35), _ts(34), "ACTIVE"),
+            ("lk-active", "DEVICE", "dev-2", "lc-1", _ts(1), _ts(-1), "ACTIVE"),  # expires tomorrow
+        ],
+    )
+ 
+    # policies: 2 inactive old, 1 active
+    conn.executemany(
+        """INSERT INTO policies
+           (policy_id, policy_version, scope, content, distributed_by, valid_until, is_active)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        [
+            ("pol-old-1", "v1", "global", "{}", "gc-1", _ts(40), 0),
+            ("pol-old-2", "v2", "global", "{}", "gc-1", _ts(35), 0),
+            ("pol-active", "v3", "global", "{}", "gc-1", _ts(-10), 1),  # valid for another 10d
+        ],
+    )
+ 
+    # events: 2 rows — these must NEVER be deleted
+    conn.executemany(
+        """INSERT INTO events
+           (event_id, event_type, actor, action, timestamp, signature, details)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        [
+            ("evt-old", "DEVICE_ADDED", "lc-1", "ADD", _ts(100), "sig", "{}"),
+            ("evt-new", "CONFIG_APPROVED", "gc-1", "APPROVE", _ts(1), "sig", "{}"),
+        ],
+    )
+ 
+    conn.commit()
+    conn.close()
+    return path
+ 
+ 
+@pytest.fixture()
+def dry_cfg(db_path: Path) -> CleanupConfig:
+    return CleanupConfig(db_path=db_path, retention_days=30, dry_run=True)
+ 
+ 
+@pytest.fixture()
+def exec_cfg(db_path: Path) -> CleanupConfig:
+    return CleanupConfig(db_path=db_path, retention_days=30, dry_run=False)
+ 
+ 
+# ---------------------------------------------------------------------------
+# Unit tests — SQL helpers
+# ---------------------------------------------------------------------------
+ 
+class TestTableExists:
+    def test_existing_table(self, db_path: Path) -> None:
+        conn = sqlite3.connect(str(db_path))
+        assert _table_exists(conn, "configs") is True
+        conn.close()
+ 
+    def test_missing_table(self, db_path: Path) -> None:
+        conn = sqlite3.connect(str(db_path))
+        assert _table_exists(conn, "nonexistent") is False
+        conn.close()
+ 
+ 
+class TestColumnExists:
+    def test_existing_column(self, db_path: Path) -> None:
+        conn = sqlite3.connect(str(db_path))
+        assert _column_exists(conn, "configs", "proposed_at") is True
+        conn.close()
+ 
+    def test_missing_column(self, db_path: Path) -> None:
+        conn = sqlite3.connect(str(db_path))
+        assert _column_exists(conn, "configs", "nonexistent_col") is False
+        conn.close()
+ 
+ 
+class TestBuildWhere:
+    def test_no_status_filter(self) -> None:
+        spec = TableSpec("t", "ts", None, 0, "")
+        where, params = _build_where(spec, datetime(2024, 1, 1, tzinfo=timezone.utc))
+        assert where == "ts < ?"
+        assert len(params) == 1
+ 
+    def test_with_status_filter(self) -> None:
+        spec = TableSpec("t", "ts", "status = 'X'", 0, "")
+        where, params = _build_where(spec, datetime(2024, 1, 1, tzinfo=timezone.utc))
+        assert "status = 'X'" in where
+        assert where.startswith("ts < ?")
+ 
+ 
+class TestCountStale:
+    def test_configs_stale_count(self, db_path: Path) -> None:
+        """Only DENIED configs older than 30 days should be counted."""
+        conn = sqlite3.connect(str(db_path))
+        spec = TableSpec("configs", "proposed_at", "status IN ('DENIED', 'ROLLED_BACK', 'FAILED')", 20, "")
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)
+        count = _count_stale(conn, spec, cutoff)
+        assert count == 2   # cfg-denied-old-1, cfg-denied-old-2
+        conn.close()
+ 
+    def test_executed_configs_excluded(self, db_path: Path) -> None:
+        """EXECUTED configs must not be counted — not in the status filter."""
+        conn = sqlite3.connect(str(db_path))
+        spec = TableSpec("configs", "proposed_at", "status IN ('DENIED', 'ROLLED_BACK', 'FAILED')", 20, "")
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)
+        count = _count_stale(conn, spec, cutoff)
+        assert count == 2   # EXECUTED row is excluded by status_filter
+        conn.close()
+ 
+    def test_unused_tokens_excluded(self, db_path: Path) -> None:
+        """Unused tokens (used=0) must not be counted even when old."""
+        conn = sqlite3.connect(str(db_path))
+        spec = TableSpec("execution_tokens", "issued_at", "used = 1", 10, "")
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)
+        count = _count_stale(conn, spec, cutoff)
+        assert count == 2   # tok-used-old-1 and tok-used-old-2 only
+        conn.close()
+ 
+    def test_zero_when_all_recent(self, db_path: Path) -> None:
+        conn = sqlite3.connect(str(db_path))
+        spec = TableSpec("discovery_reports", "scan_end", None, 30, "")
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=365)
+        count = _count_stale(conn, spec, cutoff)
+        assert count == 0
+        conn.close()
+ 
+ 
+# ---------------------------------------------------------------------------
+# Unit tests — _process_table
+# ---------------------------------------------------------------------------
+ 
+class TestProcessTableSkipCases:
+    def test_skips_immutable_events(self, db_path: Path, dry_cfg: CleanupConfig) -> None:
+        conn = sqlite3.connect(str(db_path))
+        spec = TableSpec("events", "timestamp", None, 99, "audit log")
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=1)
+        result = _process_table(conn, spec, dry_cfg, cutoff)
+        assert result.skipped is True
+        assert "immutable" in result.skip_reason.lower()
+        conn.close()
+ 
+    def test_skips_missing_table(self, db_path: Path, dry_cfg: CleanupConfig) -> None:
+        conn = sqlite3.connect(str(db_path))
+        spec = TableSpec("no_such_table", "created_at", None, 99, "")
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)
+        result = _process_table(conn, spec, dry_cfg, cutoff)
+        assert result.skipped is True
+        conn.close()
+ 
+    def test_skips_missing_column(self, db_path: Path, dry_cfg: CleanupConfig) -> None:
+        conn = sqlite3.connect(str(db_path))
+        spec = TableSpec("configs", "no_such_col", None, 99, "")
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)
+        result = _process_table(conn, spec, dry_cfg, cutoff)
+        assert result.skipped is True
+        conn.close()
+ 
+ 
+class TestProcessTableDryRun:
+    def test_correct_stale_count_for_configs(self, db_path: Path, dry_cfg: CleanupConfig) -> None:
+        conn = sqlite3.connect(str(db_path))
+        spec = TableSpec("configs", "proposed_at", "status IN ('DENIED', 'ROLLED_BACK', 'FAILED')", 20, "")
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)
+        result = _process_table(conn, spec, dry_cfg, cutoff)
+        assert result.stale_count == 2
+        assert result.deleted_count == 0
+        conn.close()
+ 
+    def test_no_rows_deleted_in_dry_run(self, db_path: Path, dry_cfg: CleanupConfig) -> None:
+        conn = sqlite3.connect(str(db_path))
+        spec = TableSpec("configs", "proposed_at", "status IN ('DENIED', 'ROLLED_BACK', 'FAILED')", 20, "")
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)
+        _process_table(conn, spec, dry_cfg, cutoff)
+        remaining = conn.execute("SELECT COUNT(*) FROM configs").fetchone()[0]
+        assert remaining == 5   # unchanged
+        conn.close()
+ 
+ 
+class TestProcessTableExecute:
+    def test_deletes_only_terminal_configs(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        conn = sqlite3.connect(str(db_path))
+        spec = TableSpec("configs", "proposed_at", "status IN ('DENIED', 'ROLLED_BACK', 'FAILED')", 20, "")
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)
+        result = _process_table(conn, spec, exec_cfg, cutoff)
+        assert result.deleted_count == 2
+        remaining = conn.execute("SELECT COUNT(*) FROM configs").fetchone()[0]
+        assert remaining == 3  # EXECUTED + 2 PENDING survive
+        conn.close()
+ 
+    def test_executed_configs_survive(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        conn = sqlite3.connect(str(db_path))
+        spec = TableSpec("configs", "proposed_at", "status IN ('DENIED', 'ROLLED_BACK', 'FAILED')", 20, "")
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)
+        _process_table(conn, spec, exec_cfg, cutoff)
+        row = conn.execute(
+            "SELECT config_id FROM configs WHERE status = 'EXECUTED'"
+        ).fetchone()
+        assert row is not None   # cfg-executed-old must still be present
+        conn.close()
+ 
+    def test_unused_tokens_survive(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        conn = sqlite3.connect(str(db_path))
+        spec = TableSpec("execution_tokens", "issued_at", "used = 1", 10, "")
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=30)
+        _process_table(conn, spec, exec_cfg, cutoff)
+        row = conn.execute(
+            "SELECT token_id FROM execution_tokens WHERE used = 0"
+        ).fetchone()
+        assert row is not None   # tok-unused-old must survive
+        conn.close()
+ 
+ 
+# ---------------------------------------------------------------------------
+# Integration tests — run_cleanup
+# ---------------------------------------------------------------------------
+ 
+class TestRunCleanupDryRun:
+    def test_returns_report(self, db_path: Path, dry_cfg: CleanupConfig) -> None:
+        report = run_cleanup(dry_cfg)
+        assert isinstance(report, CleanupReport)
+        assert report.dry_run is True
+ 
+    def test_total_deleted_is_zero(self, db_path: Path, dry_cfg: CleanupConfig) -> None:
+        report = run_cleanup(dry_cfg)
+        assert report.total_deleted == 0
+ 
+    def test_finds_stale_rows(self, db_path: Path, dry_cfg: CleanupConfig) -> None:
+        report = run_cleanup(dry_cfg)
+        assert report.total_stale > 0
+ 
+    def test_no_data_changed(self, db_path: Path, dry_cfg: CleanupConfig) -> None:
+        run_cleanup(dry_cfg)
+        conn = sqlite3.connect(str(db_path))
+        assert conn.execute("SELECT COUNT(*) FROM configs").fetchone()[0] == 5
+        assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 2
+        conn.close()
+ 
+    def test_events_always_skipped(self, db_path: Path, dry_cfg: CleanupConfig) -> None:
+        report = run_cleanup(dry_cfg)
+        events_result = next((r for r in report.results if r.table == "events"), None)
+        assert events_result is None or events_result.skipped
+ 
+ 
+class TestRunCleanupExecute:
+    def test_stale_configs_removed(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        run_cleanup(exec_cfg)
+        conn = sqlite3.connect(str(db_path))
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM configs WHERE status IN ('DENIED', 'ROLLED_BACK', 'FAILED')"
+        ).fetchone()[0]
+        assert remaining == 0
+        conn.close()
+ 
+    def test_pending_configs_survive(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        run_cleanup(exec_cfg)
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute(
+            "SELECT COUNT(*) FROM configs WHERE status = 'PENDING'"
+        ).fetchone()[0]
+        assert count == 2
+        conn.close()
+ 
+    def test_events_untouched(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        run_cleanup(exec_cfg)
+        conn = sqlite3.connect(str(db_path))
+        assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 2
+        conn.close()
+ 
+    def test_expired_locks_removed(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        run_cleanup(exec_cfg)
+        conn = sqlite3.connect(str(db_path))
+        remaining = conn.execute("SELECT COUNT(*) FROM locks").fetchone()[0]
+        assert remaining == 1   # only lk-active survives
+        conn.close()
+ 
+    def test_inactive_policies_removed(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        run_cleanup(exec_cfg)
+        conn = sqlite3.connect(str(db_path))
+        remaining = conn.execute("SELECT COUNT(*) FROM policies").fetchone()[0]
+        assert remaining == 1   # pol-active survives
+        conn.close()
+ 
+    def test_active_policy_survives(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        run_cleanup(exec_cfg)
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT policy_id FROM policies WHERE is_active = 1"
+        ).fetchone()
+        assert row is not None
+        conn.close()
+ 
+    def test_used_tokens_removed_unused_survives(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        run_cleanup(exec_cfg)
+        conn = sqlite3.connect(str(db_path))
+        used = conn.execute(
+            "SELECT COUNT(*) FROM execution_tokens WHERE used = 1 AND issued_at < ?",
+            ((datetime.now(tz=timezone.utc) - timedelta(days=30)).isoformat(),)
+        ).fetchone()[0]
+        assert used == 0
+        unused = conn.execute(
+            "SELECT COUNT(*) FROM execution_tokens WHERE used = 0"
+        ).fetchone()[0]
+        assert unused == 1
+        conn.close()
+ 
+    def test_had_no_errors(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        report = run_cleanup(exec_cfg)
+        assert not report.had_errors
+ 
+    def test_report_counts_match_reality(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        """total_deleted in the report matches what was actually removed."""
+        conn_before = sqlite3.connect(str(db_path))
+        before = {
+            t: conn_before.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0]  # noqa: S608
+            for t in ["configs", "config_records", "execution_tokens", "discovery_reports", "locks", "policies"]
+        }
+        conn_before.close()
+ 
+        report = run_cleanup(exec_cfg)
+ 
+        conn_after = sqlite3.connect(str(db_path))
+        after = {
+            t: conn_after.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0]  # noqa: S608
+            for t in before
+        }
+        conn_after.close()
+ 
+        actual_deleted = sum(before[t] - after[t] for t in before)
+        assert report.total_deleted == actual_deleted
+ 
+ 
+class TestRunCleanupEdgeCases:
+    def test_raises_on_missing_db(self, tmp_path: Path) -> None:
+        cfg = CleanupConfig(db_path=tmp_path / "ghost.db", retention_days=30)
+        with pytest.raises(FileNotFoundError):
+            run_cleanup(cfg)
+ 
+    def test_raises_on_unknown_table(self, db_path: Path) -> None:
+        cfg = CleanupConfig(db_path=db_path, retention_days=30, tables=["not_a_table"])
+        with pytest.raises(ValueError, match="Unrecognised"):
+            run_cleanup(cfg)
+ 
+    def test_filtered_to_single_table(self, db_path: Path) -> None:
+        cfg = CleanupConfig(
+            db_path=db_path, retention_days=30, dry_run=True,
+            tables=["discovery_reports"]
+        )
+        report = run_cleanup(cfg)
+        assert len(report.results) == 1
+        assert report.results[0].table == "discovery_reports"
+        assert report.results[0].stale_count == 3
+ 
+    def test_very_long_retention_finds_nothing(self, db_path: Path) -> None:
+        cfg = CleanupConfig(db_path=db_path, retention_days=3650, dry_run=True)
+        report = run_cleanup(cfg)
+        assert report.total_stale == 0
+ 
+    def test_idempotent_second_run(self, db_path: Path, exec_cfg: CleanupConfig) -> None:
+        """Running cleanup twice should leave the same result — zero stale rows."""
+        run_cleanup(exec_cfg)
+        report2 = run_cleanup(exec_cfg)
+        assert report2.total_stale == 0
+        assert report2.total_deleted == 0
+ 
+ 
+# ---------------------------------------------------------------------------
+# CLI tests — main()
+# ---------------------------------------------------------------------------
+ 
+class TestMainCLI:
+    def test_dry_run_exits_0(self, db_path: Path) -> None:
+        rc = main(["--db", str(db_path), "--days", "30"])
+        assert rc == 0
+ 
+    def test_execute_exits_0(self, db_path: Path) -> None:
+        rc = main(["--db", str(db_path), "--days", "30", "--execute"])
+        assert rc == 0
+ 
+    def test_missing_db_exits_2(self, tmp_path: Path) -> None:
+        rc = main(["--db", str(tmp_path / "missing.db"), "--days", "30"])
+        assert rc == 2
+ 
+    def test_invalid_days_exits_nonzero(self, db_path: Path) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--db", str(db_path), "--days", "0"])
+        assert exc_info.value.code != 0
+ 
+    def test_unknown_table_exits_2(self, db_path: Path) -> None:
+        rc = main(["--db", str(db_path), "--days", "30", "--tables", "not_real"])
+        assert rc == 2
+ 
+    def test_table_filter_accepted(self, db_path: Path) -> None:
+        rc = main([
+            "--db", str(db_path), "--days", "30",
+            "--tables", "discovery_reports", "locks",
+        ])
+        assert rc == 0

--- a/tests/test_cleanup_old_file.py
+++ b/tests/test_cleanup_old_file.py
@@ -6,6 +6,16 @@
 # This file is part of PDSNO.
 # See the LICENSE file in the project root for license information.
 
+"""
+tests/test_cleanup_old_data.py
+ 
+Unit and integration tests for scripts/cleanup_old_data.py.
+ 
+The tests set up a minimal subset of the PDSNO NIB schema (matching
+pdsno/datastore/nib.py and scripts/init_db.py) so cleanup logic can be
+verified without importing the full pdsno package.
+"""
+
 from __future__ import annotations
  
 import sqlite3


### PR DESCRIPTION
…lder than a retention threshold

# Pull Request — PDSNO

## Description
Provide a concise summary of the changes made in this pull request and their purpose.

> Example:  
> Added device discovery logic for ICMP Ping using asyncio to improve parallel scans.

---

## Type of Change
- [ ] 🐞 Bug fix
- [ ] 🚀 New feature
- [ ] 🧱 Refactor / Optimization
- [ ] 📘 Documentation update
- [ ] 🧩 Other (describe):

---

## Related Issues
Link related issues or discussions:

> Closes #123  
> Related to #456

---

## Architecture Impact
Describe how this change affects the overall PDSNO architecture or controllers.

> Example:  
> Affects the Local Controller communication layer by introducing MQTT message publishing.

---

## Testing
Steps or screenshots showing how this was verified:

1. Run `pytest` or the test script.
2. Verify logs for successful message exchange.
3. Check discovery results in `discovery_log.yaml`.

---

## Checklist
- [ ] Code follows style guidelines
- [ ] Documentation updated (if required)
- [ ] Tests added or updated
- [ ] No sensitive or production data exposed

---

### Reviewer Notes
Please review:
- Alignment with **PDSNO Architecture Model**
- Performance implications (if any)
- Naming consistency and code clarity
